### PR TITLE
Example of listening to User Preferences changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-#package.json
+node_modules
+build

--- a/grid-settings.php
+++ b/grid-settings.php
@@ -4,15 +4,7 @@ if (!defined('ABSPATH')) exit;
 /**
  * @param \Elementor\Core\Settings\EditorPreferences\Model $preferences The editor preferences model.
  */
-function add_preferences_controls(\Elementor\Core\Settings\EditorPreferences\Model $preferences)
-{
-
-	$styliner_grid = get_user_meta(get_current_user_id(), 'styliner_grid', true);
-
-	$styliner_grid = $styliner_grid ? 'yes' : 'no';
-	// $grid_color = $grid_color ? $grid_color : 'rgb(255 0 0 / .15)';
-	// $columns_color = $columns_color ? $columns_color : 'rgb(255 0 0 / .04)';
-	// $rows_color = $rows_color ? $rows_color : 'rgb(255 0 0 / .04)';
+function add_preferences_controls( \Elementor\Core\Settings\EditorPreferences\Model $preferences )  {
 	$preferences->start_injection(
 		[
 			'at' => 'after',
@@ -25,7 +17,7 @@ function add_preferences_controls(\Elementor\Core\Settings\EditorPreferences\Mod
 		[
 			'label' => esc_html__('Enable Styliner Grid', 'textdomain'),
 			'type' => \Elementor\Controls_Manager::SWITCHER,
-			'default' => $styliner_grid,
+			'default' => 'no',
 			'selectors' => [
 				'#styliner-grid-system' => 'display: block !important;'
 			]
@@ -51,6 +43,18 @@ function add_preferences_controls(\Elementor\Core\Settings\EditorPreferences\Mod
 		]
 	);
 
+	$preferences->add_control(
+		'styliner_grid_color',
+		[
+			'label' => esc_html__('Grid Color', 'textdomain'),
+			'type' => \Elementor\Controls_Manager::COLOR,
+			'default' => "#ff000026",
+			'condition' => [
+				'styliner_grid' => 'yes'
+			]
+		]
+	);
+
 	$preferences->end_injection();
 }
-add_action('elementor/element/editor-preferences/preferences/before_section_end', 'add_preferences_controls');
+add_action('elementor/element/editor-preferences/preferences/before_section_end', 'add_preferences_controls' );

--- a/gridliner.php
+++ b/gridliner.php
@@ -10,8 +10,8 @@ if (!defined('ABSPATH')) exit;
  * Text Domain: gridliner
  */
 
-add_filter('plugin_row_meta', function ($links_array, $plugin_file_name, $plugin_data, $status) {
-	if (strpos($plugin_file_name, basename(__FILE__))) {
+add_filter( 'plugin_row_meta' , function ( $links_array, $plugin_file_name, $plugin_data, $status ) {
+	if ( strpos( $plugin_file_name, basename( __FILE__ ) ) ) {
 
 		// You can still use `array_unshift()` to add links at the beginning.
 		$links_array[] = '<a href="https://schooliner.com/" target="_blank">סקוליינר</a>';
@@ -20,26 +20,35 @@ add_filter('plugin_row_meta', function ($links_array, $plugin_file_name, $plugin
 	}
 
 	return $links_array;
-}, 10, 4);
+}, 10, 4 );
 
-
+// this adds scripts to the preview iframe of the editor
 add_action('elementor/preview/enqueue_scripts', function () {
-	$elementor_preferences = get_user_meta(get_current_user_id(), 'elementor_preferences', true);
-	wp_register_script('gridliner', plugins_url('src/index.js', __FILE__));
-	wp_enqueue_script('gridliner');
+	$handle = 'gridliner';
+	// jquery is a needed dependency for elementor events
+	wp_register_script( $handle, plugins_url( 'src/index.js', __FILE__ ), [ 'jquery' ] );
+	wp_enqueue_script( $handle );
+});
+
+// this adds scripts to the editor panel
+add_action('elementor/editor/after_enqueue_scripts', function () {
+	$handle = 'gridliner_panel';
+	// jquery is a needed dependency for elementor events
+	wp_register_script( $handle, plugins_url( 'src/editor.js', __FILE__ ), [ 'jquery' ] );
+	wp_enqueue_script( $handle );
 });
 
 add_action('elementor/preview/enqueue_styles', function () {
-	wp_register_style('gridliner', plugins_url('src/index.css', __FILE__));
-	wp_enqueue_style('gridliner');
+	wp_register_style( 'gridliner', plugins_url( 'src/index.css', __FILE__ ) );
+	wp_enqueue_style( 'gridliner' );
 });
 
 add_action('elementor/editor/init', function () {
-	require_once plugin_dir_path(__FILE__) . '/grid-settings.php';
+	require_once plugin_dir_path( __FILE__ ) . '/grid-settings.php';
 });
 
 //Update Manager
-require plugin_dir_path(__FILE__) . 'plugin-update-checker-master/plugin-update-checker.php';
+require plugin_dir_path( __FILE__ ) . 'plugin-update-checker-master/plugin-update-checker.php';
 
 use YahnisElsts\PluginUpdateChecker\v5\PucFactory;
 

--- a/src/editor.js
+++ b/src/editor.js
@@ -1,0 +1,21 @@
+jQuery( window ).on( "elementor:init", () => {
+	// On "document:loaded" elementor event
+	elementor.on( "document:loaded", () => {
+		const updateGridEvent = new Event("stylinerGridUpdate");
+		elementor.settings.editorPreferences.model.on( 'change', ( view ) => {
+			let shouldDraw = false;
+			for ( let setting in view.changed ) {
+				// only listen to our controls
+				if ( ! [ 'styliner_grid', 'styliner_grid_color' ].includes( setting ) ) {
+					continue;
+				}
+
+				shouldDraw = true;
+			}
+
+			if ( shouldDraw ) {
+				elementor.$preview[ 0 ].contentWindow.dispatchEvent(updateGridEvent);
+			}
+		} );
+	} );
+} );

--- a/src/index.js
+++ b/src/index.js
@@ -1,81 +1,106 @@
-document.addEventListener("DOMContentLoaded", () => {
-	let html = document.documentElement
-	let body = document.body
+jQuery( window ).on( 'elementor/frontend/init', function() {
+	const init = () => {
+		// Function to create the canvas element
+		let html = document.documentElement
+		let body = document.body
 
-	let columns = 53
-	let bigColumns = 12
-	let oneColumn = 3
+		const hexToRGB = ( hex, alpha ) => {
 
-	// Default colors
-	let gridColor = "rgba(255, 0, 0, 0.15)"
-	let columnsColor = "rgba(255, 0, 0, 0.15)"
-	let rowsColor = "rgba(255, 0, 0, 0.15)"
+			const r = parseInt( hex.slice( 1, 3 ), 16 );
+			const g = parseInt( hex.slice( 3, 5 ), 16 );
+			const b = parseInt( hex.slice( 5, 7 ), 16 );
 
-	// Function to create the canvas element
-	const createCanvas = () => {
-		let canvas = document.createElement("canvas")
-		canvas.id = "styliner-grid-system"
-		body.appendChild(canvas)
+			if ( alpha ) {
+				return `rgba(${ r }, ${ g }, ${ b }, ${ alpha })`;
+			}
+
+			return `rgb(${ r }, ${ g }, ${ b })`;
+		}
+
+		const createCanvas = () => {
+			let canvas = document.createElement( "canvas" )
+			canvas.id = "styliner-grid-system"
+			body.appendChild( canvas )
+		}
+
+		// Grid drawing function with dynamic colors
+		const grid = () => {
+			if ( elementor.settings.editorPreferences.model.attributes.styliner_grid !== 'yes' ) {
+				return
+			}
+
+
+
+			let columns = 53
+			let bigColumns = 12
+			let oneColumn = 3
+
+			let gColor = ( elementor.settings.editorPreferences.model.attributes.styliner_grid_color ) ?
+				hexToRGB( elementor.settings.editorPreferences.model.attributes.styliner_grid_color, 0.5 ) :
+				"rgba(255, 0, 0, 0.15)";
+
+			// Default colors
+			let gridColor = gColor
+			let columnsColor = gColor
+			let rowsColor = gColor
+			let width = html.clientWidth
+			let height = html.offsetHeight
+
+			let columnsWidth = width / columns
+			let rows = height / columnsWidth
+			let bigColumnWidth = ( width / columns ) * oneColumn
+			let gap = 1
+			let bigRows = height / ( bigColumnWidth + gap )
+			let canvas = document.querySelector( "#styliner-grid-system" )
+			canvas.width = width
+			canvas.height = height
+
+			let c = canvas.getContext( "2d" )
+
+			// Grid
+			for ( let i = 1; i < columns; i ++ ) {
+				c.beginPath()
+				c.moveTo( columnsWidth * i, 0 )
+				c.lineTo( columnsWidth * i, height )
+				c.strokeStyle = gridColor // Use dynamic color
+				c.stroke()
+			}
+
+			for ( let i = 1; i < rows; i ++ ) {
+				c.beginPath()
+				c.moveTo( 0, columnsWidth * i )
+				c.lineTo( width, columnsWidth * i )
+				c.strokeStyle = gridColor // Use dynamic color
+				c.stroke()
+			}
+
+			// Columns
+			for ( let i = 1; i <= bigColumns; i ++ ) {
+				c.fillStyle = columnsColor // Use dynamic color
+				let x = bigColumnWidth + bigColumnWidth / 3
+				c.fillRect( x * i - bigColumnWidth / 3, 0, bigColumnWidth, height )
+			}
+
+			// Rows
+			for ( let i = 1; i <= bigRows; i ++ ) {
+				c.fillStyle = rowsColor // Use dynamic color
+				let x = bigColumnWidth + bigColumnWidth / 3
+				c.fillRect( 0, x * i - bigColumnWidth / 3, width, bigColumnWidth )
+			}
+		}
+
+		createCanvas()
+		grid()
+
+		// Attach resize and scroll events
+		document.onscroll = () => grid()
+		window.onresize = () => grid()
+		// ResizeObserver to handle updates
+		const resizeObserver = new ResizeObserver( ( entries ) => grid() )
+
+		// add custom event listener to update grid on elementor panel changes
+		window.addEventListener( 'stylinerGridUpdate', () => grid() );
 	}
+	init();
+} );
 
-	// Grid drawing function with dynamic colors
-	const grid = () => {
-		let width = html.clientWidth
-		let height = html.offsetHeight
-
-		let columnsWidth = width / columns
-		let rows = height / columnsWidth
-		let bigColumnWidth = (width / columns) * oneColumn
-		let gap = 1
-		let bigRows = height / (bigColumnWidth + gap)
-		let canvas = document.querySelector("#styliner-grid-system")
-		canvas.width = width
-		canvas.height = height
-
-		let c = canvas.getContext("2d")
-
-		// Grid
-		for (let i = 1; i < columns; i++) {
-			c.beginPath()
-			c.moveTo(columnsWidth * i, 0)
-			c.lineTo(columnsWidth * i, height)
-			c.strokeStyle = gridColor // Use dynamic color
-			c.stroke()
-		}
-
-		for (let i = 1; i < rows; i++) {
-			c.beginPath()
-			c.moveTo(0, columnsWidth * i)
-			c.lineTo(width, columnsWidth * i)
-			c.strokeStyle = gridColor // Use dynamic color
-			c.stroke()
-		}
-
-		// Columns
-		for (let i = 1; i <= bigColumns; i++) {
-			c.fillStyle = columnsColor // Use dynamic color
-			let x = bigColumnWidth + bigColumnWidth / 3
-			c.fillRect(x * i - bigColumnWidth / 3, 0, bigColumnWidth, height)
-		}
-
-		// Rows
-		for (let i = 1; i <= bigRows; i++) {
-			c.fillStyle = rowsColor // Use dynamic color
-			let x = bigColumnWidth + bigColumnWidth / 3
-			c.fillRect(0, x * i - bigColumnWidth / 3, width, bigColumnWidth)
-		}
-	}
-
-	createCanvas()
-	grid()
-
-	// Attach resize and scroll events
-	document.onscroll = () => grid()
-	window.onresize = () => grid()
-
-	// Example: Dynamically update colors (this would come from your Elementor controls)
-	// window.updateGridColors = updateColors // Expose the update function globally
-})
-
-// ResizeObserver to handle updates
-const resizeObserver = new ResizeObserver((entries) => grid())


### PR DESCRIPTION
Sorry, my linter went crazy with WP code styling..

* Added a control
* Updated the index.js => preview JS to use the panel data and listen to a custom event
* Added editor.js => panel JS to trigger the custom event on one of the plugin's control change, so you can even remove the `display: none/block !important;`  because the JS checks if its enabled or not


good luck